### PR TITLE
[WID]記事投稿機能の実装

### DIFF
--- a/app/assets/javascripts/articles.coffee
+++ b/app/assets/javascripts/articles.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,28 +1,25 @@
 class ArticlesController < ApplicationController
   before_action :set_article, only: [:show, :edit, :update, :destroy]
 
-  # GET /articles
-  # GET /articles.json
+ 
   def index
     @articles = Article.all
   end
 
-  # GET /articles/1
-  # GET /articles/1.json
+ 
   def show
   end
 
-  # GET /articles/new
+  
   def new
     @article = Article.new
   end
 
-  # GET /articles/1/edit
   def edit
   end
 
-  # POST /articles
-  # POST /articles.json
+
+
   def create
     @article = Article.new(article_params)
 
@@ -37,8 +34,7 @@ class ArticlesController < ApplicationController
     end
   end
 
-  # PATCH/PUT /articles/1
-  # PATCH/PUT /articles/1.json
+
   def update
     respond_to do |format|
       if @article.update(article_params)
@@ -51,8 +47,8 @@ class ArticlesController < ApplicationController
     end
   end
 
-  # DELETE /articles/1
-  # DELETE /articles/1.json
+  
+  
   def destroy
     @article.destroy
     respond_to do |format|
@@ -62,12 +58,12 @@ class ArticlesController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
+    
     def set_article
       @article = Article.find(params[:id])
     end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
+    
     def article_params
       params.require(:article).permit(:title, :author, :text)
     end


### PR DESCRIPTION
#what
記事投稿機能を実施する。
railsのscaffoldを用いてarticleモデルを作成し、titleカラム、authorカラム、textカラムを作成した。

#why
記事投稿機能は本アプリケーションの根幹機能であるため。